### PR TITLE
tui: enable 'd' to mark Done in Inspect view (In Review→Done)

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -317,6 +317,19 @@ export function App() {
 				setDeleting({ active: true, task: inspecting.task });
 				return;
 			}
+			// Mark as Done from detail view
+			if (input === "d") {
+				if (!board || !inspecting.task) return;
+				void completeTask(
+					board,
+					inspecting.task,
+					setBoard,
+					setInspecting,
+					setCursor,
+					setMessage,
+				);
+				return;
+			}
 			if (input === "s") {
 				if (!board || !inspecting.task || !config) return;
 				void startTask(


### PR DESCRIPTION
- Adds 'd' handler in Inspect view for tasks in In Review
- Calls completeTask to move to Done and clear worktree
- No change to list view behavior; 'm' and 'r' unchanged

Please review.