### PR TITLE
tui: add 'Ctrl+J to newline' hint while editing title/description

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -699,7 +699,7 @@ export function App() {
                                     setMessage("");
                                 }}
                             />
-                            <Text dimColor>  Enter to submit • Esc to cancel • Tab to switch</Text>
+                            <Text dimColor>  Enter to submit • Esc to cancel • Tab to switch • Ctrl+J to newline</Text>
                         </Box>
                         <Box>
                             <Text>Description (optional): </Text>
@@ -723,7 +723,7 @@ export function App() {
                                 }}
                             />
                         </Box>
-                        <Text dimColor>Enter to submit • Esc to cancel • Tab/Shift+Tab to switch • Leave description empty to skip</Text>
+                        <Text dimColor>Enter to submit • Esc to cancel • Tab/Shift+Tab to switch • Ctrl+J to newline • Leave description empty to skip</Text>
                     </Box>
                 ) : deleting.active && deleting.task ? (
 					<Text>
@@ -790,7 +790,7 @@ export function App() {
                     )}
 					<Text dimColor>
 						{detailEditing.active
-							? "Tab/Shift+Tab to switch • Esc to cancel"
+							? "Tab/Shift+Tab to switch • Esc to cancel • Ctrl+J to newline"
 							: "Press e to edit"
 						}
 					</Text>
@@ -843,7 +843,7 @@ export function App() {
 					)}
 					<Text dimColor>
 						{detailEditing.active
-							? "Enter to save • Esc to cancel • Tab/Shift+Tab to switch"
+							? "Enter to save • Esc to cancel • Tab/Shift+Tab to switch • Ctrl+J to newline"
 							: "Press e to edit • hjkl/arrow to switch • Enter/Esc to close"
 						}
 					</Text>


### PR DESCRIPTION
編集中のガイダンスに『Ctrl+Jで改行』を追記しました。

- 新規作成(Title) 入力欄のヘルプに追加
- 新規作成(Description) 入力欄のヘルプに追加
- 詳細画面 Title 編集中のヘルプに追加
- 詳細画面 Description 編集中のヘルプに追加

目的:
- Enterで決定、Escでキャンセルする挙動のまま、改行したいときの操作を明示

影響範囲:
- 文字列のUIヘルプのみ（機能変更なし）

確認:
- Loading board…
[2K[1A[2K[GLoading board…
[2K[1A[2K[G
  ERROR Raw mode is not supported on the current process.stdin, which Ink uses
       as input stream by default.
       Read about how to prevent this error on
       https://github.com/vadimdemedes/ink/#israwmodesupported

 - Read about how to prevent this error on
   https://github.com/vadimdemedes/ink/#israwmodesupported\t
 - handleSetRawMode (node_modules/ink/build/components/App.js:108:27)
 - <anonymous> (node_modules/ink/build/hooks/use-input.js:36:9)
 -react-stack-bottom (node_modules/react-reconciler/cjs/react-reconciler.develo
  frame             pment.js:15945:20)
 -runWithFiberIn (node_modules/react-reconciler/cjs/react-reconciler.developmen
  EV            t.js:1738:13)
 -commitHookEffectLis (node_modules/react-reconciler/cjs/react-reconciler.devel
  Mount              opment.js:9516:29)
 -commitHookPassiveMoun (node_modules/react-reconciler/cjs/react-reconciler.dev
  Effects              elopment.js:9639:11)
 -commitPassiveMountO (node_modules/react-reconciler/cjs/react-reconciler.devel
  Fiber              opment.js:11364:13)
 -recursivelyTraversePassiv (node_modules/react-reconciler/cjs/react-reconciler
  MountEffects             .development.js:11338:11)
 -commitPassiveMountO (node_modules/react-reconciler/cjs/react-reconciler.devel
  Fiber              opment.js:11479:11)
 -recursivelyTraversePassiv (node_modules/react-reconciler/cjs/react-reconciler
  MountEffects             .development.js:11338:11) を起動し、各編集状態でヘルプに『Ctrl+J to newline』が表示されることを確認。