### PR TITLE
docs: READMEにクイックスタートと設定のキーバインドを追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,59 @@ bun install
 bun run install-bin            # ローカルでビルドして /usr/local/bin にインストール
 ```
 
+## 使い方（クイックスタート）
+
+### 基本操作
+
+- 新規タスク: `n` でタイトル入力し To Do に追加
+- 着手: タスク選択後に `s` で In Progress（Git ブランチ＆worktree を自動作成）
+- エディタ起動: `o`（`~/.vibedove/config.json` の `editor` または `$EDITOR` を使用）
+- 完了/中止: `d` で Done、`x` で Cancelled（対応する worktree は削除）
+- 移動/選択: `h`/`l`（左右）・`j`/`k`（上下）または矢印キー、ヘルプ: `?`、終了: `q`
+
+### 設定（任意）
+
+設定ファイルを開く:
+
+- `c`: プロジェクト別設定をエディタで開く／未作成なら自動作成
+    - パス: `~/.vibedove/projects/<repo>/config.json`
+    - 保存してエディタを閉じると TUI が設定を再読み込みします
+- `C`: グローバル設定をエディタで開く／未作成なら自動作成
+    - パス: `~/.vibedove/config.json`
+    - 保存してエディタを閉じると TUI が設定を再読み込みします
+- 使用エディタ: `config.editor` があればそれを、なければ環境変数 `$EDITOR` を使用します（未設定の場合は TUI に案内が表示されます）。
+
+
+プロジェクト別設定: `~/.vibedove/projects/<repo>/config.json`
+
+```jsonc
+{
+  "setupScript": "bun install",
+  "copyFiles": ".env .env.local"
+}
+```
+
+グローバル設定: `~/.vibedove/config.json`
+
+```jsonc
+{
+  "branchPrefix": "vd",
+  "defaultBaseBranch": null,
+  "tmpRoot": null,
+  "remoteName": "origin",
+  "editor": "code"
+}
+```
+
+ボードの保存先:
+
+- `~/.vibedove/projects/<repo>/board.json` に自動生成・保存されます（リポジトリ配下には作成しません）。
+
+作業ツリーとブランチ:
+
+- ブランチ名: `vd/task/<id>-<slug>`（既定。`branchPrefix` で変更可）
+- 作成場所: `${TMPDIR}/vibedove/worktrees/vd-<id>-<slug>`（Done/Cancelled 時に worktree を削除）
+
 ## 開発
 
 依存関係のインストール:


### PR DESCRIPTION
READMEに以下を追記しました:\n- 使い方（クイックスタート）\n- 設定ファイルの開き方（c: プロジェクト設定 / C: グローバル設定）\n- 基本操作のサマリ、worktree/ブランチの方針、保存場所\n\nご確認お願いします。